### PR TITLE
Changed type and view naming

### DIFF
--- a/IO/Common.vhdl
+++ b/IO/Common.vhdl
@@ -52,7 +52,7 @@ package Common is
 		array(natural range <>)
 		of Differatial_Interface;
 
-	alias LVDS_Interface_Vector is T_DS_Vector;
+	alias LVDS_Interface_Vector is Differatial_Interface;
 
 
 	-- Transceiver lanes with differential signaling

--- a/IO/Common.vhdl
+++ b/IO/Common.vhdl
@@ -32,56 +32,62 @@ use     IEEE.std_logic_1164.all;
 
 package Common is
 	-- Differential signaling (DS or LVDS)
-	type T_DS is record
+	type Differatial_Interface is record
 		P : std_logic;
 		N : std_logic;
 	end record;
 
-	alias T_LVDS        is T_DS;
+	alias LVDS_Interface        is Differatial_Interface;
 
-	view V_DS_Out of T_DS is
+	view Differatial_OutView of Differatial_Interface is
 		P : out;
 		N : out;
 	end view;
-	alias V_DS_In is V_DS_Out'converse;
+	alias Differatial_InView is Differatial_OutView'converse;
 
-	alias V_LVDS_Out is V_DS_Out;
-	alias V_LVDS_In  is V_DS_In;
+	alias LVDS_OutView is Differatial_OutView;
+	alias LVDS_InView  is Differatial_InView;
 
-	type T_DS_Vector is array(natural range <>) of T_DS;
+	type Differatial_Interface_Vector is
+		array(natural range <>)
+		of Differatial_Interface;
 
-	alias T_LVDS_Vector is T_DS_Vector;
+	alias LVDS_Interface_Vector is T_DS_Vector;
 
 
 	-- Transceiver lanes with differential signaling
-	type T_DS_Lane is record
-		TX : T_DS;
-		RX : T_DS;
+	type DifferentialLane_Interface is record
+		TX : Differatial_Interface;
+		RX : Differatial_Interface;
 	end record;
 
-	view V_DS_Lane of T_DS_Lane is
-		TX : view V_DS_Out;
-		RX : view V_DS_In;
+	view DifferentialLane_TransmitterView of DifferentialLane_Interface is
+		TX : view Differatial_OutView;
+		RX : view Differatial_InView;
 	end view;
 
-	type T_DS_Lane_Vector is array(natural range <>) of T_DS_Lane;
+	type DifferentialLane_Interface_Vector is
+		array(natural range <>)
+		of DifferentialLane_Interface;
 
-	alias T_LVDS_Lane_Vector is T_DS_Lane_Vector;
+	alias LVDSLane_Interface_Vector is DifferentialLane_Interface_Vector;
 
 
 	-- Tristate (3-state) interface
-	type T_Tristate is record
+	type Tristate_Interface is record
 		I : std_logic;      -- Input
 		O : std_logic;      -- Output
 		T : std_logic;      -- Tristate / OutputEnable_n
 	end record;
 
-	view V_Tristate_Out of T_Tristate is
+	view Tristate_OutView of Tristate_Interface is
 		I : in;
 		O : out;
 		T : out;
 	end view;
-	alias V_Tristate_In is V_Tristate_Out'converse;
+	alias Tristate_InView is Tristate_OutView'converse;
 
-	type T_Tristate_Vector is array(natural range <>) of T_Tristate;
+	type Tristate_Interface_Vector is
+		array(natural range <>)
+		of Tristate_Interface;
 end package;

--- a/IO/I2C.vhdl
+++ b/IO/I2C.vhdl
@@ -10,6 +10,13 @@
 -- -------------------------------------
 -- This package 
 --
+--   Interface name:    I2C (Inter-Integrated Circuit)
+--   Alternative names: Two-Wire-Interface (TWI)
+--   Can be reused for: PMBus, SMBus
+--   Developed by:      Philips / NXP Semiconductor
+--   Standard/Manual:   http://www.nxp.com/documents/user_manual/UM10204.pdf
+--   Further links:     https://en.wikipedia.org/wiki/I%C2%B2C
+--
 -- License:
 -- =============================================================================
 -- Copyright 2016-2020 Open Source VHDL Group
@@ -37,31 +44,33 @@ use     work.Common.all;
 -- SDA -> Serial Data
 package I2C is
 	-- Chip external interface (PCB level)
-	type T_I2C_PCB is record
+	type I2C_PCB_Interface is record
 		SCL : std_logic;
 		SDA : std_logic;
 	end record;
 
-	view V_I2C_PCB of T_I2C_PCB is
+	view I2C_PCB_View of I2C_PCB_Interface is
 		SCL : inout;
 		SDA : inout;
 	end view;
 
-	type T_I2C_PCB_Vector is array(natural range <>) of T_I2C_PCB;
+	type I2C_PCB_Interface_vector is
+		array(natural range <>)
+		of I2C_PCB_Interface;
 	
 
 	-- Chip internal interface, not supporting bidirectional signals (fabric level)
-	type T_I2C is record
-		SCL  : T_TriState;
-		SDA  : T_TriState;
+	type I2C_Interface is record
+		SCL  : Tristate_Interface;
+		SDA  : Tristate_Interface;
 	end record;
 
-	view V_I2C_Out of T_I2C is
-		SCL : view V_Tristate_Out;
-		SDA : view V_TriState_Out;
+	view I2C_ControllerView of I2C_Interface is
+		SCL : view Tristate_OutView;
+		SDA : view Tristate_OutView;
 	end view;
-	alias V_I2C_In is V_I2C_Out'converse;
+	alias I2C_IOBView is I2C_ControllerView'converse;
 
-	type T_I2C_Vector is array(natural range <>) of T_I2C;
+	type I2C_Interface_Vector is array(natural range <>) of I2C_Interface;
 
 end package;

--- a/IO/JTAG.vhdl
+++ b/IO/JTAG.vhdl
@@ -10,6 +10,11 @@
 -- -------------------------------------
 -- This package 
 --
+--   Interface name:    Joint Test Action Group (JTAG)
+--   Developed by:      Joint Test Action Group (JTAG)
+--   Standard/Manual:   IEEE Standard 1149.1-1990 - Standard Test Access Port and Boundary-Scan Architecture
+--   Further links:     https://en.wikipedia.org/wiki/JTAG
+--
 -- License:
 -- =============================================================================
 -- Copyright 2016-2020 Open Source VHDL Group
@@ -37,7 +42,7 @@ use     IEEE.std_logic_1164.all;
 -- TDI  -> Test Data In    
 -- TDO  -> Test Data Out   
 package JTAG is
-	type T_JTAG is record
+	type JTAG_Interface is record
 		TCK  : std_logic;
 		TRST : std_logic;
 		TMS  : std_logic;
@@ -45,13 +50,13 @@ package JTAG is
 		TDO  : std_logic;
 	end record;
 
-	view V_JTAG_In of T_JTAG is
+	view JTAG_ChipView of JTAG_Interface is
 		TCK  : in;
 		TRST : in;
 		TMS  : in;
 		TDI  : in;
 		TDO  : out;
 	end view;
-	alias V_JTAG_Out is V_JTAG_In'converse;
+	alias JTAG_TesterView is JTAG_ChipView'converse;
 
 end package;

--- a/IO/SPI.vhdl
+++ b/IO/SPI.vhdl
@@ -36,20 +36,20 @@ use     IEEE.std_logic_1164.all;
 -- MISO -> Master In/Slave Out
 -- SS_n -> Slave Select; low-active
 package SPI is
-	type T_SPI is record
+	type SPI_Interface is record
 		SCLK : std_logic;
 		MOSI : std_logic;
 		MISO : std_logic;
 		SS_n : std_logic_vector;
 	end record;
 
-	view V_SPI_Out of T_SPI is
+	view SPI_MasterView of SPI_Interface is
 		SCLK  : out;
 		MOSI  : out;
 		MISO  : in;
 		SS_n  : out;
 	end view;
-	alias V_SPI_In is V_SPI_Out'converse;
+	alias SPI_SlaveView is SPI_MasterView'converse;
 
-	type T_SPI_Vector is array(natural range <>) of T_SPI;
+	type SPI_Interface_Vector is array(natural range <>) of SPI_Interface;
 end package;


### PR DESCRIPTION
This PR addresses #10.

* [x] `T_...` that we use `_Interface` or `Interface` for interface types  
  **Applied change:** using `_Interface`
* [x] `T_...` that we use something that is understood naturally without a secret decoder ring.  
  **Applied change:** currently, there are no ordinary types in the packages, all are records defining an *interface*.
* [x] `V_...` that we use `_View` or `View` 
  **Applied change:** using `_View`
* [x] For `..._In` also consider In as suffix (w/o _).  
  "In" follows main data flow. Similar thoughts for ...Out
  * Like: `I2C_InView` vs. `I2CViewIn` vs. `I2CView_In`
  * No Like: `I2CInView` vs. `I2C_In_View` vs. `I2C_View_In`
  
  **Applied change:** using `_InView` and `_OutView` respectively.
* [x] For each interface there shall be a vector of that interface also declared of the form: `_Interface_Vector`
  **Applied change:** requirement was already fulfilled
* [x] `_PCB` vs FPGA Internals
  **Applied change:** PCB related signals use suffix `_PCB`, which fabric signal have no suffix.
* [x] Review naming for AddressBus which historically was Master/Initiator and Slave/Target
  **Applied change:** Different names chooses, if not dictated by the standard itself. If the standard changes naming, these definitions can be changed too.
* [x] AxiAddress should be unsigned.  
  **Applied change:** AXI is not part of this repo yet, will be applied when AXI is uploaded.

--------------
/cc @JimLewis see [changes](https://github.com/VHDL/Interfaces/pull/12/files)